### PR TITLE
Rename 'conf_mode' to 'bootproto'.

### DIFF
--- a/plugins/network/app/controllers/network_controller.rb
+++ b/plugins/network/app/controllers/network_controller.rb
@@ -92,10 +92,10 @@ class NetworkController < ApplicationController
 
     # FIXME tests for YSRB
 
-    @conf_mode = ifc.bootproto
-    @conf_mode = STATIC_BOOT_ID if @conf_mode.blank?
+    @bootproto = ifc.bootproto
+    @bootproto = STATIC_BOOT_ID if @bootproto.blank?
 
-    if @conf_mode == STATIC_BOOT_ID
+    if @bootproto == STATIC_BOOT_ID
       ipaddr = ifc.ipaddr
     else
       ipaddr = "/"
@@ -120,8 +120,8 @@ class NetworkController < ApplicationController
     @nameservers = dns.nameservers
     @searchdomains = dns.searches
     @default_route = rt.via
-    @conf_modes = {_("Manual")=>STATIC_BOOT_ID, _("Automatic")=>"dhcp"}
-    @conf_modes[@conf_mode] =@conf_mode unless @conf_modes.has_value? @conf_mode
+    @bootprotos = {_("Manual")=>STATIC_BOOT_ID, _("Automatic")=>"dhcp"}
+    @bootprotos[@bootproto] =@bootproto unless @bootprotos.has_value? @bootproto
   end
 
 
@@ -174,10 +174,10 @@ class NetworkController < ApplicationController
     ifc = Interface.find params["interface"]
     return false unless ifc
     
-    dirty_ifc = true unless (ifc.bootproto == params["conf_mode"])
+    dirty_ifc = true unless (ifc.bootproto == params["bootproto"])
     logger.info "dirty after interface config: #{dirty}"
     
-    ifc.bootproto=params["conf_mode"]
+    ifc.bootproto=params["bootproto"]
     
     if ifc.bootproto==STATIC_BOOT_ID
       #ip addr is returned in another state then given, but restart of static address is not problem

--- a/plugins/network/app/views/network/index.html.erb
+++ b/plugins/network/app/views/network/index.html.erb
@@ -127,12 +127,12 @@
         <div class="left">
           <label class="plugin-icon-container"><img class="plugin-icon" src="/icons/network.png"></label>
           <label class="plugin-name"><%=_("Network")%></label><span id="questionMark" style="margin:2px 15px; float:none;">?</span>
-          <%=text_field_tag :conf_mode, @conf_mode, :type=>"hidden", :disabled => write_disabled %>
+          <%=text_field_tag :bootproto, @bootproto, :type=>"hidden", :disabled => write_disabled %>
         </div>
 
         <div class="right" >
           <span class="right" style="padding:2px; background:#fff; -moz-border-radius:2px; -webkit-border-radius:2px;">
-          <% if(@conf_mode != 'static') %>
+          <% if(@bootproto != 'static') %>
             <button id="autoMode" class="active" value="dhcp"><%=_("Automatic")%></button>
             <button id="manualMode" value="static"><%=_("Manual")%></button>
           <% else %>

--- a/plugins/network/test/functional/network_controller_test.rb
+++ b/plugins/network/test/functional/network_controller_test.rb
@@ -85,7 +85,7 @@ class NetworkControllerTest < ActionController::TestCase
   end
 
   def test_dhcp_without_change
-    put :update, { :interface => "eth2", :conf_mode => "dhcp", :default_route => "192.168.1.1", :nameservers => "192.168.1.2 192.168.1.42", :searchdomains => "labs.example.com example.com", :hostname => "arthur", :domain => "britons" }
+    put :update, { :interface => "eth2", :bootproto => "dhcp", :default_route => "192.168.1.1", :nameservers => "192.168.1.2 192.168.1.42", :searchdomains => "labs.example.com example.com", :hostname => "arthur", :domain => "britons" }
     assert_response :redirect
     assert_redirected_to :controller => "controlpanel", :action => "index"
   end

--- a/webclient/public/javascripts/webyast-network.js
+++ b/webclient/public/javascripts/webyast-network.js
@@ -31,7 +31,7 @@ $(function(){
   var $auto = $('#autoMode');
   var $manual = $('#manualMode');
       
-  $("#conf_mode").val() == "dhcp"? enableAuto(): enableStatic();
+  $("#bootproto").val() == "dhcp"? enableAuto(): enableStatic();
   
   function enableAuto() {
     $('#dnsForm').find('div.auto').hide();
@@ -51,12 +51,12 @@ $(function(){
     if($id.val() == "dhcp") {
       $auto.addClass('active');
       $manual.removeClass('active');
-      $('#conf_mode').val($auto.val());
+      $('#bootproto').val($auto.val());
       enableAuto();
     } else {
       $manual.addClass('active');
       $auto.removeClass('active');
-      $('#conf_mode').val($manual.val());
+      $('#bootproto').val($manual.val());
       enableStatic()
     }
   }


### PR DESCRIPTION
'bootproto' is used everywhere else and calling it 'conf_mode' for no reason
just creates confusion.
